### PR TITLE
Regex fallback mode

### DIFF
--- a/forward-port.sh
+++ b/forward-port.sh
@@ -1,0 +1,1 @@
+adb forward tcp:1313 localabstract:minicap

--- a/run.sh
+++ b/run.sh
@@ -26,7 +26,15 @@ fi
 args=
 if [ "$1" = "autosize" ]; then
   set +o pipefail
-  size=$(adb shell dumpsys window | grep -Eo 'init=\d+x\d+' | head -1 | cut -d= -f 2)
+  size=$(adb shell dumpsys window | grep -Eo 'init=[0-9]+x[0-9]+' | head -1 | cut -d= -f 2)
+  if [ "$size" = "" ]; then
+    w=$(adb shell dumpsys window | grep -Eo 'DisplayWidth=[0-9]+' | head -1 | cut -d= -f 2)
+    h=$(adb shell dumpsys window | grep -Eo 'DisplayHeight=[0-9]+' | head -1 | cut -d= -f 2)
+    size="${w}x${h}"
+  fi
+  if [ "$size" = "" ]; then
+    size=$(adb shell dumpsys window | grep -Eo 'init=\d+x\d+' | head -1 | cut -d= -f 2)
+  fi
   if [ "$size" = "" ]; then
     w=$(adb shell dumpsys window | grep -Eo 'DisplayWidth=\d+' | head -1 | cut -d= -f 2)
     h=$(adb shell dumpsys window | grep -Eo 'DisplayHeight=\d+' | head -1 | cut -d= -f 2)


### PR DESCRIPTION
Hi,

on some Linux distributions (for ex. Ubuntu 16.10) regexes used to obtain device screen size seems not to work.

The solution is to check for `init=[0-9]+x[0-9]+` in addition to `init=\d+x\d+`.

Best regards,
Marcin