### PR TITLE
Pre-release check fails on Mac

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ sdk=$(adb shell getprop ro.build.version.sdk | tr -d '\r')
 pre=$(adb shell getprop ro.build.version.preview_sdk | tr -d '\r')
 rel=$(adb shell getprop ro.build.version.release | tr -d '\r')
 
-if [[ -z "$pre" ]]; then
+if [ ! -n "$pre" ]; then
   sdk=$(($sdk + 1))
 fi
 


### PR DESCRIPTION
The `-z` check returns true even for empty strings on Mac OSX sierra. This fix solves the problem.