### PR TITLE
Latest NDK compatibility: Use c++_static, clang

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,10 +1,8 @@
-NDK_TOOLCHAIN_VERSION := 4.9
-
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 
 # Get C++11 working
 APP_CPPFLAGS += -std=c++11 -fexceptions
-APP_STL := gnustl_static
+APP_STL := c++_static
 
 # Disable PIE for SDK <16 support. Enable manually for >=5.0
 # where necessary.


### PR DESCRIPTION
Add compatibility with the latest version of the NDK, and use clang and `c++_static`

https://developer.android.com/ndk/guides/cpp-support.html
https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md