### PR TITLE
Let the user define a frame rate

### DIFF
--- a/jni/minicap/minicap.cpp
+++ b/jni/minicap/minicap.cpp
@@ -251,7 +251,7 @@ main(int argc, char* argv[]) {
       break;
     case 'r':
       frameRate = atof(optarg);
-      if(frameRate == 0.0) {
+      if(frameRate <= 0.0) {
         MCINFO("Invalid framerate '%s', expecting a float > 0", optarg);
         return EXIT_FAILURE;
       } else {

--- a/jni/minicap/minicap.cpp
+++ b/jni/minicap/minicap.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <sys/socket.h>
+#include <thread>
 
 #include <cmath>
 #include <condition_variable>
@@ -44,6 +45,7 @@ usage(const char* pname) {
     "  -Q <value>:    JPEG quality (0-100).\n"
     "  -s:            Take a screenshot and output it to stdout. Needs -P.\n"
     "  -S:            Skip frames when they cannot be consumed quickly enough.\n"
+    "  -r <value>:    Frame rate (frames/s)"
     "  -t:            Attempt to get the capture method running, then exit.\n"
     "  -i:            Get display information in JSON format. May segfault.\n"
     "  -h:            Show help.\n",
@@ -210,6 +212,7 @@ main(int argc, char* argv[]) {
   const char* sockname = DEFAULT_SOCKET_NAME;
   uint32_t displayId = DEFAULT_DISPLAY_ID;
   unsigned int quality = DEFAULT_JPG_QUALITY;
+  int framePeriodMs = 0;
   bool showInfo = false;
   bool takeScreenshot = false;
   bool skipFrames = false;
@@ -217,7 +220,8 @@ main(int argc, char* argv[]) {
   Projection proj;
 
   int opt;
-  while ((opt = getopt(argc, argv, "d:n:P:Q:siSth")) != -1) {
+  while ((opt = getopt(argc, argv, "d:n:P:Q:r:siSth")) != -1) {
+    float frameRate;
     switch (opt) {
     case 'd':
       displayId = atoi(optarg);
@@ -244,6 +248,17 @@ main(int argc, char* argv[]) {
       break;
     case 'S':
       skipFrames = true;
+      break;
+    case 'r':
+      frameRate = atof(optarg);
+      if(frameRate == 0.0) {
+        MCINFO("Invalid framerate '%s', expecting a float > 0", optarg);
+        return EXIT_FAILURE;
+      } else {
+        framePeriodMs = 1000/frameRate;
+        skipFrames = true;
+        MCINFO("framerate: %.2f (period %d ms)", frameRate, framePeriodMs);
+      }
       break;
     case 't':
       testOnly = true;
@@ -455,6 +470,7 @@ main(int argc, char* argv[]) {
 
     int pending, err;
     while (!gWaiter.isStopped() && (pending = gWaiter.waitForFrame()) > 0) {
+      auto frameAvailableAt = std::chrono::steady_clock::now();
       if (skipFrames && pending > 1) {
         // Skip frames if we have too many. Not particularly thread safe,
         // but this loop should be the only consumer anyway (i.e. nothing
@@ -511,6 +527,9 @@ main(int argc, char* argv[]) {
       // to do it here or the loop will stop.
       minicap->releaseConsumedFrame(&frame);
       haveFrame = false;
+      if(framePeriodMs > 0) {
+        std::this_thread::sleep_until(frameAvailableAt + std::chrono::milliseconds(framePeriodMs));
+      }
     }
 
 close:


### PR DESCRIPTION
Add a '-r' command line parameter to provide a float value
defining the frame rate.
The frame rate is achieved by suspending the main thread
periodically to limit the amount of processed frames.
This implies enabling skipFrames in order to send the latest
available data.