### PR TITLE
Recover proper url and description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,24 @@
 {
   "name": "minicap-prebuilt",
   "version": "2.3.2",
-  "description": "Orange prebuilt binaries of minicap for OpenSTF.",
+  "description": "Prebuilt binaries of minicap.",
   "keywords": [
     "minicap"
   ],
   "bugs": {
-    "url": "https://github.com/Orange-OpenSource/minicap/issues"
+    "url": "https://github.com/openstf/minicap/issues"
   },
   "license": "Apache-2.0",
   "author": {
-    "name": "Orange",
-    "url": "https://opensource.orange.com/"
+    "name": "The OpenSTF Project",
+    "email": "contact@openstf.io",
+    "url": "https://openstf.io"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Orange-OpenSource/minicap.git"
+    "url": "https://github.com/openstf/minicap.git"
   },
   "scripts": {
     "prepublish": "make"
-  },
-  "files": [
-    "prebuilt"
-  ]
+  }
 }


### PR DESCRIPTION
url and description from the fork that originated the PR
(changed to avoid confusion between packages) unexpectedly
ended up in the upstream repo.